### PR TITLE
add support for getting Orientation tag

### DIFF
--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -41,6 +41,7 @@ class Exif
     const JOB_TITLE             = 'jobTitle';
     const KEYWORDS              = 'keywords';
     const MIMETYPE              = 'MimeType';
+    const ORIENTATION           = 'Orientation';
     const SOFTWARE              = 'software';
     const SOURCE                = 'source';
     const TITLE                 = 'title';
@@ -437,5 +438,41 @@ class Exif
         }
         
         return $this->data[self::FILESIZE];
+    }
+
+    /**
+     * Returns the orientation, if it exists
+     *
+     * @return integer
+     */
+    public function getOrientation()
+    {
+        if (!isset($this->data[self::ORIENTATION])) {
+            return false;
+        }
+
+        $value = $this->data[self::ORIENTATION];
+
+        // normalize exiftool strings to raw integer values
+        switch ($value) {
+            case 'Horizontal (normal)':
+                return 1;
+            case 'Mirror horizontal':
+                return 2;
+            case 'Rotate 180':
+                return 3;
+            case 'Mirror vertical':
+                return 4;
+            case 'Mirror horizontal and rotate 270 CW':
+                return 5;
+            case 'Rotate 90 CW':
+                return 6;
+            case 'Mirror horizontal and rotate 90 CW':
+                return 7;
+            case 'Rotate 270 CW':
+                return 8;
+            default:
+                return $value;
+        }
     }
 }

--- a/lib/PHPExif/Reader/Adapter/Exiftool.php
+++ b/lib/PHPExif/Reader/Adapter/Exiftool.php
@@ -166,6 +166,7 @@ class Exiftool extends AdapterAbstract
             Exif::JOB_TITLE             => false,
             Exif::KEYWORDS              => (!isset($source['Keywords'])) ? false : $source['Keywords'],
             Exif::MIMETYPE              => false,
+            Exif::ORIENTATION           => (!isset($source['Orientation'])) ? false : $source['Orientation'],
             Exif::SOFTWARE              => (!isset($source['Software'])) ? false : $source['Software'],
             Exif::SOURCE                => false,
             Exif::TITLE                 => (!isset($source['Title'])) ? false : $source['Title'],

--- a/lib/PHPExif/Reader/Adapter/Native.php
+++ b/lib/PHPExif/Reader/Adapter/Native.php
@@ -271,6 +271,7 @@ class Native extends AdapterAbstract
             Exif::JOB_TITLE             => (!isset($source[self::SECTION_IPTC]['jobtitle'])) ? false : $source[self::SECTION_IPTC]['jobtitle'],
             Exif::KEYWORDS              => (!isset($source[self::SECTION_IPTC]['keywords'])) ? false : $source[self::SECTION_IPTC]['keywords'],
             Exif::MIMETYPE              => (!isset($source[Exif::MIMETYPE]) ? false : $source[Exif::MIMETYPE]),
+            Exif::ORIENTATION           => (!isset($source[Exif::ORIENTATION]) ? false : $source[Exif::ORIENTATION]),
             Exif::SOFTWARE              => (!isset($source['Software'])) ? false : $source['Software'],
             Exif::SOURCE                => (!isset($source[self::SECTION_IPTC]['source'])) ? false : $source[self::SECTION_IPTC]['source'],
             Exif::TITLE                 => (!isset($source[self::SECTION_IPTC]['title'])) ? false : $source[self::SECTION_IPTC]['title'],

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -385,4 +385,46 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $this->exif->setRawData($data);
         $this->assertEquals($expected, $this->exif->getFileSize());
     }
+
+    public function testGetOrientation()
+    {
+        $expected = 1;
+        $data[\PHPExif\Exif::ORIENTATION] = $expected;
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+
+        // test normalization of exiftool strings to raw integer values
+        $expected = 1;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Horizontal (normal)';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 2;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Mirror horizontal';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 3;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Rotate 180';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 4;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Mirror vertical';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 5;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Mirror horizontal and rotate 270 CW';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 6;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Rotate 90 CW';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 7;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Mirror horizontal and rotate 90 CW';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+        $expected = 8;
+        $data[\PHPExif\Exif::ORIENTATION] = 'Rotate 270 CW';
+        $this->exif->setRawData($data);
+        $this->assertEquals($expected, $this->exif->getOrientation());
+    }
 }


### PR DESCRIPTION
The new `Exif::getOrientation()` function always returns an integer value (like it is returned by `exif_read_data` and `exiftool -n`). Because the exiftool adapter calls exiftool without the -n switch, the string values return by exiftool are converted to integers. It seems a bit odd that exiftool first converts the raw integer value into a human readable string and we convert it back to the original integer but to change this we need to call exiftool with the -n switch which would be a BC break.