### PR TITLE
unify output from Native and Exiftool adapters

### DIFF
--- a/lib/PHPExif/Reader/Adapter/Exiftool.php
+++ b/lib/PHPExif/Reader/Adapter/Exiftool.php
@@ -28,13 +28,18 @@ use \DateTime;
 class Exiftool extends AdapterAbstract
 {
     const TOOL_NAME = 'exiftool';
-    
+
     /**
      * Path to the exiftool binary
      *
      * @var string
      */
     protected $toolPath;
+
+    /**
+     * @var boolean
+     */
+    protected $numeric = true;
 
     /**
      * Setter for the exiftool binary path
@@ -57,6 +62,14 @@ class Exiftool extends AdapterAbstract
         $this->toolPath = $path;
         
         return $this;
+    }
+
+    /**
+     * @param boolean $numeric
+     */
+    public function setNumeric($numeric)
+    {
+        $this->numeric = $numeric;
     }
     
     /**
@@ -86,9 +99,10 @@ class Exiftool extends AdapterAbstract
     {
         $result = $this->getCliOutput(
             sprintf(
-                '%1$s -j %2$s',
+                '%1$s%3$s -j %2$s',
                 $this->getToolPath(),
-                $file
+                $file,
+                $this->numeric ? ' -n' : ''
             )
         );
         
@@ -145,6 +159,13 @@ class Exiftool extends AdapterAbstract
             $focalLengthParts = explode(' ', $source['FocalLength']);
             $focalLength = (int) reset($focalLengthParts);
         }
+
+        $exposureTime = false;
+        if (isset($source['ExposureTime'])) {
+            $exposureTime = '1/' . round(1 / $source['ExposureTime']);
+        }
+
+        //var_dump($source);
         
         return array(
             Exif::APERTURE              => (!isset($source['Aperture'])) ? false : sprintf('f/%01.1f', $source['Aperture']),
@@ -155,7 +176,7 @@ class Exiftool extends AdapterAbstract
             Exif::COPYRIGHT             => false,
             Exif::CREATION_DATE         => (!isset($source['CreateDate'])) ? false : DateTime::createFromFormat('Y:m:d H:i:s', $source['CreateDate']),
             Exif::CREDIT                => false,
-            Exif::EXPOSURE              => (!isset($source['ShutterSpeed'])) ? false : $source['ShutterSpeed'],
+            Exif::EXPOSURE              => $exposureTime,
             Exif::FILESIZE              => false,
             Exif::FOCAL_LENGTH          => $focalLength,
             Exif::FOCAL_DISTANCE        => (!isset($source['ApproximateFocusDistance'])) ? false : sprintf('%1$sm', $source['ApproximateFocusDistance']),
@@ -165,7 +186,7 @@ class Exiftool extends AdapterAbstract
             Exif::ISO                   => (!isset($source['ISO'])) ? false : $source['ISO'],
             Exif::JOB_TITLE             => false,
             Exif::KEYWORDS              => (!isset($source['Keywords'])) ? false : $source['Keywords'],
-            Exif::MIMETYPE              => false,
+            Exif::MIMETYPE              => (!isset($source['MIMEType'])) ? false : $source['MIMEType'],
             Exif::ORIENTATION           => (!isset($source['Orientation'])) ? false : $source['Orientation'],
             Exif::SOFTWARE              => (!isset($source['Software'])) ? false : $source['Software'],
             Exif::SOURCE                => false,

--- a/lib/PHPExif/Reader/Adapter/Exiftool.php
+++ b/lib/PHPExif/Reader/Adapter/Exiftool.php
@@ -165,31 +165,36 @@ class Exiftool extends AdapterAbstract
             $exposureTime = '1/' . round(1 / $source['ExposureTime']);
         }
 
-        //var_dump($source);
+        $caption = false;
+        if (isset($source['Caption'])) {
+            $caption = $source['Caption'];
+        } elseif (isset($source['Caption-Abstract'])) {
+            $caption = $source['Caption-Abstract'];
+        }
         
         return array(
             Exif::APERTURE              => (!isset($source['Aperture'])) ? false : sprintf('f/%01.1f', $source['Aperture']),
-            Exif::AUTHOR                => false,
+            Exif::AUTHOR                => (!isset($source['Artist'])) ? false : $source['Artist'],
             Exif::CAMERA                => (!isset($source['Model'])) ? false : $source['Model'],
-            Exif::CAPTION               => false,
+            Exif::CAPTION               => $caption,
             Exif::COLORSPACE            => (!isset($source[Exif::COLORSPACE]) ? false : $source[Exif::COLORSPACE]),
-            Exif::COPYRIGHT             => false,
+            Exif::COPYRIGHT             => (!isset($source['Copyright'])) ? false : $source['Copyright'],
             Exif::CREATION_DATE         => (!isset($source['CreateDate'])) ? false : DateTime::createFromFormat('Y:m:d H:i:s', $source['CreateDate']),
-            Exif::CREDIT                => false,
+            Exif::CREDIT                => (!isset($source['Credit'])) ? false : $source['Credit'],
             Exif::EXPOSURE              => $exposureTime,
-            Exif::FILESIZE              => false,
+            Exif::FILESIZE              => (!isset($source[Exif::FILESIZE]) ? false : $source[Exif::FILESIZE]),
             Exif::FOCAL_LENGTH          => $focalLength,
             Exif::FOCAL_DISTANCE        => (!isset($source['ApproximateFocusDistance'])) ? false : sprintf('%1$sm', $source['ApproximateFocusDistance']),
-            Exif::HEADLINE              => false,
+            Exif::HEADLINE              => (!isset($source['Headline'])) ? false : $source['Headline'],
             Exif::HEIGHT                => (!isset($source['ImageHeight'])) ? false : $source['ImageHeight'],
             Exif::HORIZONTAL_RESOLUTION => (!isset($source['XResolution'])) ? false : $source['XResolution'],
             Exif::ISO                   => (!isset($source['ISO'])) ? false : $source['ISO'],
-            Exif::JOB_TITLE             => false,
+            Exif::JOB_TITLE             => (!isset($source['JobTitle'])) ? false : $source['JobTitle'],
             Exif::KEYWORDS              => (!isset($source['Keywords'])) ? false : $source['Keywords'],
             Exif::MIMETYPE              => (!isset($source['MIMEType'])) ? false : $source['MIMEType'],
             Exif::ORIENTATION           => (!isset($source['Orientation'])) ? false : $source['Orientation'],
             Exif::SOFTWARE              => (!isset($source['Software'])) ? false : $source['Software'],
-            Exif::SOURCE                => false,
+            Exif::SOURCE                => (!isset($source['Source'])) ? false : $source['Source'],
             Exif::TITLE                 => (!isset($source['Title'])) ? false : $source['Title'],
             Exif::VERTICAL_RESOLUTION   => (!isset($source['YResolution'])) ? false : $source['YResolution'],
             Exif::WIDTH                 => (!isset($source['ImageWidth'])) ? false : $source['ImageWidth'],

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -427,4 +427,33 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $this->exif->setRawData($data);
         $this->assertEquals($expected, $this->exif->getOrientation());
     }
+
+    /**
+     * Test that the values returned by both adapters are equal
+     */
+    public function testAdapterConsistency()
+    {
+        $reflClass = new \ReflectionClass('\PHPExif\Exif');
+        $methods = $reflClass->getMethods(ReflectionMethod::IS_PUBLIC);
+        $file = PHPEXIF_TEST_ROOT . '/files/morning_glory_pool_500.jpg';
+
+        $adapter_exiftool = new \PHPExif\Reader\Adapter\Exiftool();
+        $adapter_native = new \PHPExif\Reader\Adapter\Native();
+
+        $result_exiftool = $adapter_exiftool->getExifFromFile($file);
+        $result_native = $adapter_native->getExifFromFile($file);
+
+        // find all Getter methods on the results and compare its output
+        foreach ($methods as $method) {
+            $name = $method->getName();
+            if (strpos($name, 'get') !== 0 || $name == 'getRawData') {
+                continue;
+            }
+            $this->assertEquals(
+                call_user_func(array($result_native, $name)),
+                call_user_func(array($result_exiftool, $name)),
+                'Adapter difference in method ' . $name
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR basically adds 3 changes:

- A new `ExifTest::testAdapterConsistency` test method that ensures that the Exiftool adapter returns the same values as the Native adapter does for all property getters of the resulting `Exif`object

- Exiftool adapter adds the `-n` switch to the `exiftool` call

- All properties that previously were hardcoded to be `false` in Exiftool adapter are changed so that they return the same values as the Native adapter for the test image.

This is really tested only for the test image `morning_glory_pool_500.jpg`. We need to add more test images for the `ExifTest::testAdapterConsistency` test and if they fail on some property adjust the adapters accordingly.
