### PR TITLE
Geolocation

### DIFF
--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -204,7 +204,7 @@ class Native extends AdapterAbstract
      */
     public function getIptcData($file)
     {
-        $size = getimagesize($file, $info);
+        getimagesize($file, $info);
         $arrData = array();
         if (isset($info['APP13'])) {
             $iptc = iptcparse($info['APP13']);

--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -486,7 +486,7 @@ class Exif
     }
 
     /**
-     * Returns raw GPS coordinates, if it exists
+     * Returns GPS coordinates, if it exists
      *
      * @return array|boolean
      */
@@ -497,107 +497,5 @@ class Exif
         }
 
         return $this->data[self::GPS];
-    }
-
-    /**
-     * Returns GPS in degrees, minutes and seconds, if it exists
-     *
-     * @return string|boolean
-     */
-    public function getGPSDegMinSec()
-    {
-        return $this->getFormattedGPS('degrees_minutes_seconds');
-    }
-
-    /**
-     * Returns GPS in degrees, and decimal minutes, if it exists
-     *
-     * @return string|boolean
-     */
-    public function getGPSDecMinutes()
-    {
-        return $this->getFormattedGPS('decimal_minutes');
-    }
-
-    /**
-     * Returns GPS in decimal degrees, if it exists
-     *
-     * @return string|boolean
-     */
-    public function getGPSDecDegrees()
-    {
-        return $this->getFormattedGPS('decimal_degrees');
-    }
-
-    /**
-     * Returns formatted GPS coordinates, if it exists
-     *
-     * @param string $format
-     * @return string|boolean
-     */
-    public function getFormattedGPS($format = 'decimal_minutes')
-    {
-        if (!isset($this->data[self::GPS]) || $this->data[self::GPS] === false) {
-            return false;
-        }
-
-        if ($format === 'degrees_minutes_seconds') {
-            $gps = $this->data[self::GPS];
-
-            return sprintf(
-                '%d° %d\' %s" %s, %d° %d\' %s" %s',
-                $gps['latitude'][0],
-                $gps['latitude'][1],
-                $gps['latitude'][2],
-                $gps['latitude'][3],
-                $gps['longitude'][0],
-                $gps['longitude'][1],
-                $gps['longitude'][2],
-                $gps['longitude'][3]
-            );
-        }
-
-        return $this->getGPSDecimal($format);
-    }
-
-    /**
-     * Returns decimal formatted GPS coordinates, if it exists
-     *
-     * @param string $format
-     * @return string
-     * @throws \InvalidArgumentException If the the format is not valid
-     */
-    protected function getGPSDecimal($format)
-    {
-        $gps = $this->data[self::GPS];
-
-        $latMinutes = $gps['latitude'][1] / 60 + $gps['latitude'][2] / 3600;
-        $lonMinutes = $gps['longitude'][1] / 60 + $gps['longitude'][2] / 3600;
-
-        switch ($format) {
-            case 'decimal_minutes':
-                return sprintf(
-                    '%d° %f\' %s, %d° %f\' %s',
-                    $gps['latitude'][0],
-                    $latMinutes,
-                    $gps['latitude'][3],
-                    $gps['longitude'][0],
-                    $lonMinutes,
-                    $gps['longitude'][3]
-                );
-                break;
-
-            case 'decimal_degrees':
-                return sprintf(
-                    '%f, %f',
-                    ($gps['latitude'][3] === 'S' ? -1 : 1) * ($gps['latitude'][0] + $latMinutes),
-                    ($gps['longitude'][3] === 'W' ? -1 : 1) * ($gps['longitude'][0] + $lonMinutes)
-                );
-                break;
-
-            default:
-                throw new \InvalidArgumentException(sprintf('GPS format "%s" is not valid', $format));
-                break;
-        }
     }
 }

--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -47,6 +47,7 @@ class Exif
     const TITLE                 = 'title';
     const VERTICAL_RESOLUTION   = 'verticalResolution';
     const WIDTH                 = 'width';
+    const GPS                   = 'gps';
 
     /**
      * The mapped EXIF data
@@ -427,7 +428,7 @@ class Exif
 
         return $this->data[self::CREATION_DATE];
     }
-    
+
     /**
      * Returns the colorspace, if it exists
      *
@@ -438,10 +439,10 @@ class Exif
         if (!isset($this->data[self::COLORSPACE])) {
             return false;
         }
-        
+
         return $this->data[self::COLORSPACE];
     }
-    
+
     /**
      * Returns the mimetype, if it exists
      *
@@ -452,13 +453,13 @@ class Exif
         if (!isset($this->data[self::MIMETYPE])) {
             return false;
         }
-        
+
         return $this->data[self::MIMETYPE];
     }
-    
+
     /**
      * Returns the filesize, if it exists
-     * 
+     *
      * @return integer
      */
     public function getFileSize()
@@ -466,7 +467,7 @@ class Exif
         if (!isset($this->data[self::FILESIZE])) {
             return false;
         }
-        
+
         return $this->data[self::FILESIZE];
     }
 
@@ -482,5 +483,121 @@ class Exif
         }
 
         return $this->data[self::ORIENTATION];
+    }
+
+    /**
+     * Returns raw GPS coordinates, if it exists
+     *
+     * @return array|boolean
+     */
+    public function getGPS()
+    {
+        if (!isset($this->data[self::GPS])) {
+            return false;
+        }
+
+        return $this->data[self::GPS];
+    }
+
+    /**
+     * Returns GPS in degrees, minutes and seconds, if it exists
+     *
+     * @return string|boolean
+     */
+    public function getGPSDegMinSec()
+    {
+        return $this->getFormattedGPS('degrees_minutes_seconds');
+    }
+
+    /**
+     * Returns GPS in degrees, and decimal minutes, if it exists
+     *
+     * @return string|boolean
+     */
+    public function getGPSDecMinutes()
+    {
+        return $this->getFormattedGPS('decimal_minutes');
+    }
+
+    /**
+     * Returns GPS in decimal degrees, if it exists
+     *
+     * @return string|boolean
+     */
+    public function getGPSDecDegrees()
+    {
+        return $this->getFormattedGPS('decimal_degrees');
+    }
+
+    /**
+     * Returns formatted GPS coordinates, if it exists
+     *
+     * @param string $format
+     * @return string|boolean
+     */
+    public function getFormattedGPS($format = 'decimal_minutes')
+    {
+        if (!isset($this->data[self::GPS]) || $this->data[self::GPS] === false) {
+            return false;
+        }
+
+        if ($format === 'degrees_minutes_seconds') {
+            $gps = $this->data[self::GPS];
+
+            return sprintf(
+                '%d° %d\' %s" %s, %d° %d\' %s" %s',
+                $gps['latitude'][0],
+                $gps['latitude'][1],
+                $gps['latitude'][2],
+                $gps['latitude'][3],
+                $gps['longitude'][0],
+                $gps['longitude'][1],
+                $gps['longitude'][2],
+                $gps['longitude'][3]
+            );
+        }
+
+        return $this->getGPSDecimal($format);
+    }
+
+    /**
+     * Returns decimal formatted GPS coordinates, if it exists
+     *
+     * @param string $format
+     * @return string
+     * @throws \InvalidArgumentException If the the format is not valid
+     */
+    protected function getGPSDecimal($format)
+    {
+        $gps = $this->data[self::GPS];
+
+        $latMinutes = $gps['latitude'][1] / 60 + $gps['latitude'][2] / 3600;
+        $lonMinutes = $gps['longitude'][1] / 60 + $gps['longitude'][2] / 3600;
+
+        switch ($format) {
+            case 'decimal_minutes':
+                return sprintf(
+                    '%d° %f\' %s, %d° %f\' %s',
+                    $gps['latitude'][0],
+                    $latMinutes,
+                    $gps['latitude'][3],
+                    $gps['longitude'][0],
+                    $lonMinutes,
+                    $gps['longitude'][3]
+                );
+                break;
+
+            case 'decimal_degrees':
+                return sprintf(
+                    '%f, %f',
+                    ($gps['latitude'][3] === 'S' ? -1 : 1) * ($gps['latitude'][0] + $latMinutes),
+                    ($gps['longitude'][3] === 'W' ? -1 : 1) * ($gps['longitude'][0] + $lonMinutes)
+                );
+                break;
+
+            default:
+                throw new \InvalidArgumentException(sprintf('GPS format "%s" is not valid', $format));
+                break;
+        }
     }
 }

--- a/tests/PHPExif/Adapter/ExiftoolTest.php
+++ b/tests/PHPExif/Adapter/ExiftoolTest.php
@@ -130,7 +130,9 @@ class ExiftoolTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group exiftool
+     * @covers \PHPExif\Adapter\Exiftool::setNumeric
      * @covers \PHPExif\Adapter\Exiftool::mapData
+     * @covers \PHPExif\Adapter\Exiftool::extractGPSCoordinates
      */
     public function testMapDataCreationDegGPSIsCalculated()
     {
@@ -151,6 +153,7 @@ class ExiftoolTest extends \PHPUnit_Framework_TestCase
     /**
      * @group exiftool
      * @covers \PHPExif\Adapter\Exiftool::mapData
+     * @covers \PHPExif\Adapter\Exiftool::extractGPSCoordinates
      */
     public function testMapDataCreationNumericGPSIsCalculated()
     {

--- a/tests/PHPExif/Adapter/ExiftoolTest.php
+++ b/tests/PHPExif/Adapter/ExiftoolTest.php
@@ -137,21 +137,14 @@ class ExiftoolTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setNumeric(false);
         $result = $this->adapter->mapData(
             array(
-                'GPSLatitudeRef'  => 'North',
                 'GPSLatitude'     => '40 deg 20\' 0.42857" N',
-                'GPSLongitudeRef' => 'West',
+                'GPSLatitudeRef'  => 'North',
                 'GPSLongitude'    => '20 deg 10\' 2.33333" W',
-                'GPSAltitudeRef'  => 'Above Sea Level',
-                'GPSAltitude'     => '1 m Above Sea Level'
+                'GPSLongitudeRef' => 'West',
             )
         );
 
-        $expected = array(
-            'latitude'  => array(40, 20, 0.42857, 'N'),
-            'longitude' => array(20, 10, 2.33333, 'W'),
-            'altitude'  => array(1, 0),
-        );
-
+        $expected = '40.333452380556,-20.167314813889';
         $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
     }
 
@@ -163,21 +156,14 @@ class ExiftoolTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->adapter->mapData(
             array(
-                'GPSLatitudeRef'  => 'North',
                 'GPSLatitude'     => '40.333452381',
-                'GPSLongitudeRef' => 'West',
+                'GPSLatitudeRef'  => 'North',
                 'GPSLongitude'    => '20.167314814',
-                'GPSAltitudeRef'  => 'Below Sea Level',
-                'GPSAltitude'     => '1 m Above Sea Level'
+                'GPSLongitudeRef' => 'West',
             )
         );
 
-        $expected = array(
-            'latitude'  => array(40, 20, 0.428572, 'N'),
-            'longitude' => array(20, 10, 2.33333, 'W'),
-            'altitude'  => array(1, -1),
-        );
-
+        $expected = '40.333452381,-20.167314814';
         $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
     }
 

--- a/tests/PHPExif/Adapter/ExiftoolTest.php
+++ b/tests/PHPExif/Adapter/ExiftoolTest.php
@@ -130,6 +130,59 @@ class ExiftoolTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group exiftool
+     * @covers \PHPExif\Adapter\Exiftool::mapData
+     */
+    public function testMapDataCreationDegGPSIsCalculated()
+    {
+        $this->adapter->setNumeric(false);
+        $result = $this->adapter->mapData(
+            array(
+                'GPSLatitudeRef'  => 'North',
+                'GPSLatitude'     => '40 deg 20\' 0.42857" N',
+                'GPSLongitudeRef' => 'West',
+                'GPSLongitude'    => '20 deg 10\' 2.33333" W',
+                'GPSAltitudeRef'  => 'Above Sea Level',
+                'GPSAltitude'     => '1 m Above Sea Level'
+            )
+        );
+
+        $expected = array(
+            'latitude'  => array(40, 20, 0.42857, 'N'),
+            'longitude' => array(20, 10, 2.33333, 'W'),
+            'altitude'  => array(1, 0),
+        );
+
+        $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
+    }
+
+    /**
+     * @group exiftool
+     * @covers \PHPExif\Adapter\Exiftool::mapData
+     */
+    public function testMapDataCreationNumericGPSIsCalculated()
+    {
+        $result = $this->adapter->mapData(
+            array(
+                'GPSLatitudeRef'  => 'North',
+                'GPSLatitude'     => '40.333452381',
+                'GPSLongitudeRef' => 'West',
+                'GPSLongitude'    => '20.167314814',
+                'GPSAltitudeRef'  => 'Below Sea Level',
+                'GPSAltitude'     => '1 m Above Sea Level'
+            )
+        );
+
+        $expected = array(
+            'latitude'  => array(40, 20, 0.428572, 'N'),
+            'longitude' => array(20, 10, 2.33333, 'W'),
+            'altitude'  => array(1, -1),
+        );
+
+        $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
+    }
+
+    /**
+     * @group exiftool
      * @covers \PHPExif\Adapter\Exiftool::getCliOutput
      */
     public function testGetCliOutput()

--- a/tests/PHPExif/Adapter/NativeTest.php
+++ b/tests/PHPExif/Adapter/NativeTest.php
@@ -323,6 +323,8 @@ class NativeTest extends \PHPUnit_Framework_TestCase
     /**
      * @group native
      * @covers \PHPExif\Adapter\Native::mapData
+     * @covers \PHPExif\Adapter\Native::extractGPSCoordinate
+     * @covers \PHPExif\Adapter\Native::normalizeGPSComponent
      */
     public function testMapDataCreationGPSIsCalculated()
     {

--- a/tests/PHPExif/Adapter/NativeTest.php
+++ b/tests/PHPExif/Adapter/NativeTest.php
@@ -328,21 +328,14 @@ class NativeTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->adapter->mapData(
             array(
-                'GPSLatitudeRef'  => 'N',
                 'GPSLatitude'     => array('40/1', '20/1', '15/35'),
-                'GPSLongitudeRef' => 'W',
+                'GPSLatitudeRef'  => 'N',
                 'GPSLongitude'    => array('20/1', '10/1', '35/15'),
-                'GPSAltitudeRef'  => '\000',
-                'GPSAltitude'     => '1'
+                'GPSLongitudeRef' => 'W',
             )
         );
 
-        $expected = array(
-            'latitude'  => array(40, 20, 0.42857142857143, 'N'),
-            'longitude' => array(20, 10, 2.3333333333333, 'W'),
-            'altitude'  => array(1, 0),
-        );
-
+        $expected = '40.333452380952,-20.167314814815';
         $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
     }
 }

--- a/tests/PHPExif/Adapter/NativeTest.php
+++ b/tests/PHPExif/Adapter/NativeTest.php
@@ -319,4 +319,30 @@ class NativeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('DateTime', $result[\PHPExif\Exif::CREATION_DATE]);
     }
+
+    /**
+     * @group native
+     * @covers \PHPExif\Adapter\Native::mapData
+     */
+    public function testMapDataCreationGPSIsCalculated()
+    {
+        $result = $this->adapter->mapData(
+            array(
+                'GPSLatitudeRef'  => 'N',
+                'GPSLatitude'     => array('40/1', '20/1', '15/35'),
+                'GPSLongitudeRef' => 'W',
+                'GPSLongitude'    => array('20/1', '10/1', '35/15'),
+                'GPSAltitudeRef'  => '\000',
+                'GPSAltitude'     => '1'
+            )
+        );
+
+        $expected = array(
+            'latitude'  => array(40, 20, 0.42857142857143, 'N'),
+            'longitude' => array(20, 10, 2.3333333333333, 'W'),
+            'altitude'  => array(1, 0),
+        );
+
+        $this->assertEquals($expected, $result[\PHPExif\Exif::GPS]);
+    }
 }

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -449,27 +449,13 @@ class ExifTest extends \PHPUnit_Framework_TestCase
     /**
      * @group exif
      * @covers \PHPExif\Exif::getGPS
-     * @covers \PHPExif\Exif::getGPSDegMinSec
-     * @covers \PHPExif\Exif::getGPSDecMinutes
-     * @covers \PHPExif\Exif::getGPSDecDegrees
-     * @expectedException InvalidArgumentException
      */
     public function testGetGPS()
     {
-        $expected = array(
-            'latitude'  => array(40, 20, 10, 'N'),
-            'longitude' => array(10, 5, 1, 'W'),
-            'altitude'  => array(0, 0),
-        );
+        $expected = '40.333452380556,-20.167314813889';
         $data[\PHPExif\Exif::GPS] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getGPS());
-
-        $this->assertEquals('40° 20\' 10" N, 10° 5\' 1" W', $this->exif->getGPSDegMinSec());
-        $this->assertEquals('40° 0.336111\' N, 10° 0.083611\' W', $this->exif->getGPSDecMinutes());
-        $this->assertEquals('40.336111, -10.083611', $this->exif->getGPSDecDegrees());
-
-        $this->exif->getFormattedGPS('unknown_format');
     }
 
     /**

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -401,7 +401,7 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getJobtitle());
     }
-    
+
     /**
      * @group exif
      * @covers \PHPExif\Exif::getColorSpace
@@ -413,7 +413,7 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getColorSpace());
     }
-    
+
     /**
      * @group exif
      * @covers \PHPExif\Exif::getMimeType
@@ -425,7 +425,7 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getMimeType());
     }
-    
+
     /**
      * @group exif
      * @covers \PHPExif\Exif::getFileSize
@@ -444,6 +444,32 @@ class ExifTest extends \PHPUnit_Framework_TestCase
         $data[\PHPExif\Exif::ORIENTATION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getOrientation());
+    }
+
+    /**
+     * @group exif
+     * @covers \PHPExif\Exif::getGPS
+     * @covers \PHPExif\Exif::getGPSDegMinSec
+     * @covers \PHPExif\Exif::getGPSDecMinutes
+     * @covers \PHPExif\Exif::getGPSDecDegrees
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetGPS()
+    {
+        $expected = array(
+            'latitude'  => array(40, 20, 10, 'N'),
+            'longitude' => array(10, 5, 1, 'W'),
+            'altitude'  => array(0, 0),
+        );
+        $data[\PHPExif\Exif::GPS] = $expected;
+        $this->exif->setData($data);
+        $this->assertEquals($expected, $this->exif->getGPS());
+
+        $this->assertEquals('40° 20\' 10" N, 10° 5\' 1" W', $this->exif->getGPSDegMinSec());
+        $this->assertEquals('40° 0.336111\' N, 10° 0.083611\' W', $this->exif->getGPSDecMinutes());
+        $this->assertEquals('40.336111, -10.083611', $this->exif->getGPSDecDegrees());
+
+        $this->exif->getFormattedGPS('unknown_format');
     }
 
     /**


### PR DESCRIPTION
## Need
Geolocation of images, read GPS coordinates from exif gps data

## Solution
Both native and exiftool adapters mapData methods have been updated to extract GPS coordinates from exif data

There is no point on having GPS coordinates manipulation on a library which purpose is exif data extraction so I've normalize them to [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees) format and created [juliangut/gps](https://github.com/juliangut/gps) for this coordinates manipulation

## Additionally
Found an unused variable in getIptcData method on native adapter

*sorry for the spaces removed on empty lines, editor config*