### PR TITLE
Escape shell arguments

### DIFF
--- a/lib/PHPExif/Adapter/Exiftool.php
+++ b/lib/PHPExif/Adapter/Exiftool.php
@@ -100,15 +100,13 @@ class Exiftool extends AdapterAbstract
      */
     public function getExifFromFile($file)
     {
-        $gpsFormat = '%d deg %d\' %.4f\"';
-
         $result = $this->getCliOutput(
             sprintf(
-                '%1$s%3$s -j -c "%4$s" %2$s',
+                '%1$s%3$s -j -c %4$s %2$s',
                 $this->getToolPath(),
-                $file,
+                escapeshellarg($file),
                 $this->numeric ? ' -n' : '',
-                $gpsFormat
+                escapeshellarg('%d deg %d\' %.4f"')
             )
         );
 


### PR DESCRIPTION
If the filename or path contains spaces, the output of a command will be empty.