### PR TITLE
Fixed normalization of zero degrees coordinates

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -162,25 +162,16 @@ class Exiftool implements MapperInterface
         }
 
         // add GPS coordinates, if available
-        if (count($gpsData) === 2) {
-            $latitude = $gpsData['lat'];
-            $longitude = $gpsData['lon'];
+        if (count($gpsData) === 2 && $gpsData['lat'] !== false && $gpsData['lon'] !== false) {
+            $gpsLocation = sprintf(
+                '%s,%s',
+                (isset($data['GPSLatitudeRef'][0]) && strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $gpsData['lat'],
+                (isset($data['GPSLongitudeRef'][0]) && strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $gpsData['lon']
+            );
 
-            if ($latitude !== false && $longitude !== false) {
-                $gpsLocation = sprintf(
-                    '%s,%s',
-                    (strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $latitude,
-                    (strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $longitude
-                );
-
-                $key = $this->map[self::GPSLATITUDE];
-
-                $mappedData[$key] = $gpsLocation;
-            } else {
-                unset($mappedData[$this->map[self::GPSLATITUDE]]);
-            }
+            $mappedData[Exif::GPS] = $gpsLocation;
         } else {
-            unset($mappedData[$this->map[self::GPSLATITUDE]]);
+            unset($mappedData[Exif::GPS]);
         }
 
         return $mappedData;

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -163,8 +163,8 @@ class Exiftool implements MapperInterface
 
         // add GPS coordinates, if available
         if (count($gpsData) === 2 && $gpsData['lat'] !== false && $gpsData['lon'] !== false) {
-            $latitudeRef = isset($data['GPSLatitudeRef'][0]) ? $data['GPSLatitudeRef'][0] : null;
-            $longitudeRef = isset($data['GPSLongitudeRef'][0]) ? $data['GPSLongitudeRef'][0] : null;
+            $latitudeRef = empty($data['GPSLatitudeRef'][0]) ? 'N' : $data['GPSLatitudeRef'][0];
+            $longitudeRef = empty($data['GPSLongitudeRef'][0]) ? 'E' : $data['GPSLongitudeRef'][0];
 
             $gpsLocation = sprintf(
                 '%s,%s',

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -163,10 +163,13 @@ class Exiftool implements MapperInterface
 
         // add GPS coordinates, if available
         if (count($gpsData) === 2 && $gpsData['lat'] !== false && $gpsData['lon'] !== false) {
+            $latitudeRef = isset($data['GPSLatitudeRef'][0]) ? $data['GPSLatitudeRef'][0] : null;
+            $longitudeRef = isset($data['GPSLongitudeRef'][0]) ? $data['GPSLongitudeRef'][0] : null;
+
             $gpsLocation = sprintf(
                 '%s,%s',
-                (isset($data['GPSLatitudeRef'][0]) && strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $gpsData['lat'],
-                (isset($data['GPSLongitudeRef'][0]) && strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $gpsData['lon']
+                (strtoupper($latitudeRef) === 'S' ? -1 : 1) * $gpsData['lat'],
+                (strtoupper($longitudeRef) === 'W' ? -1 : 1) * $gpsData['lon']
             );
 
             $mappedData[Exif::GPS] = $gpsLocation;

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -219,7 +219,11 @@ class Native implements MapperInterface
     {
         $components = array_map(array($this, 'normalizeGPSComponent'), $components);
 
-        return intval($components[0]) + (intval($components[1]) / 60) + (floatval($components[2]) / 3600);
+        if (count($components) > 2) {
+            return intval($components[0]) + (intval($components[1]) / 60) + (floatval($components[2]) / 3600);
+        }
+
+        return reset($components);
     }
 
     /**
@@ -232,14 +236,14 @@ class Native implements MapperInterface
     {
         $parts = explode('/', $component);
 
-        if (count($parts) > 0) {
+        if (count($parts) > 1) {
             if ($parts[1]) {
-                return (int) $parts[0] / (int) $parts[1];
+                return intval($parts[0]) / intval($parts[1]);
             }
 
             return 0;
         }
 
-        return $parts[0];
+        return floatval(reset($parts));
     }
 }

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -181,10 +181,13 @@ class Native implements MapperInterface
 
         // add GPS coordinates, if available
         if (count($gpsData) === 2) {
+            $latitudeRef = isset($data['GPSLatitudeRef'][0]) ? $data['GPSLatitudeRef'][0] : null;
+            $longitudeRef = isset($data['GPSLongitudeRef'][0]) ? $data['GPSLongitudeRef'][0] : null;
+
             $gpsLocation = sprintf(
                 '%s,%s',
-                (isset($data['GPSLatitudeRef'][0]) && strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $gpsData['lat'],
-                (isset($data['GPSLongitudeRef'][0]) && strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $gpsData['lon']
+                (strtoupper($latitudeRef) === 'S' ? -1 : 1) * $gpsData['lat'],
+                (strtoupper($longitudeRef) === 'W' ? -1 : 1) * $gpsData['lon']
             );
 
             $mappedData[Exif::GPS] = $gpsLocation;

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -225,6 +225,14 @@ class Native implements MapperInterface
     {
         $parts = explode('/', $component);
 
-        return count($parts) === 1 ? $parts[0] : (int) reset($parts) / (int) end($parts);
+        if (count($parts) > 0) {
+            if ($parts[1]) {
+                return (int) $parts[0] / (int) $parts[1];
+            }
+
+            return 0;
+        }
+
+        return $parts[0];
     }
 }

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -181,8 +181,8 @@ class Native implements MapperInterface
 
         // add GPS coordinates, if available
         if (count($gpsData) === 2) {
-            $latitudeRef = isset($data['GPSLatitudeRef'][0]) ? $data['GPSLatitudeRef'][0] : null;
-            $longitudeRef = isset($data['GPSLongitudeRef'][0]) ? $data['GPSLongitudeRef'][0] : null;
+            $latitudeRef = empty($data['GPSLatitudeRef'][0]) ? 'N' : $data['GPSLatitudeRef'][0];
+            $longitudeRef = empty($data['GPSLongitudeRef'][0]) ? 'E' : $data['GPSLongitudeRef'][0];
 
             $gpsLocation = sprintf(
                 '%s,%s',

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -179,13 +179,17 @@ class Native implements MapperInterface
             $mappedData[$key] = $value;
         }
 
+        // add GPS coordinates, if available
         if (count($gpsData) === 2) {
             $gpsLocation = sprintf(
                 '%s,%s',
-                (strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $gpsData['lat'],
-                (strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $gpsData['lon']
+                (isset($data['GPSLatitudeRef'][0]) && strtoupper($data['GPSLatitudeRef'][0]) === 'S' ? -1 : 1) * $gpsData['lat'],
+                (isset($data['GPSLongitudeRef'][0]) && strtoupper($data['GPSLongitudeRef'][0]) === 'W' ? -1 : 1) * $gpsData['lon']
             );
+
             $mappedData[Exif::GPS] = $gpsLocation;
+        } else {
+            unset($mappedData[Exif::GPS]);
         }
 
         return $mappedData;

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -120,6 +120,21 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Exiftool::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresIncorrectCreationDate()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Exiftool::CREATEDATE => '2015:04:01',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(false, reset($mapped));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -175,17 +175,25 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
      */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
-        $result = $this->mapper->mapRawData(
-            array(
+        $expected = array(
+            '40.333452380952,-20.167314814815' => array(
                 'GPSLatitude'     => array('40/1', '20/1', '15/35'),
                 'GPSLatitudeRef'  => 'N',
                 'GPSLongitude'    => array('20/1', '10/1', '35/15'),
                 'GPSLongitudeRef' => 'W',
-            )
+            ),
+            '0,-0' => array(
+                'GPSLatitude'     => array('0/0', '0/0', '0/0'),
+                'GPSLatitudeRef'  => 'N',
+                'GPSLongitude'    => array('0/0', '0/0', '0/0'),
+                'GPSLongitudeRef' => 'W',
+            ),
         );
 
-        $expected = '40.333452380952,-20.167314814815';
-        $this->assertEquals($expected, reset($result));
+        foreach ($expected as $key => $value) {
+            $result = $this->mapper->mapRawData($value);
+            $this->assertEquals($key, reset($result));
+        }
     }
 
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -90,6 +90,21 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Native::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresIncorrectDateTimeOriginal()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(false, reset($mapped));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(
@@ -186,6 +201,12 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
                 'GPSLatitude'     => array('0/0', '0/0', '0/0'),
                 'GPSLatitudeRef'  => 'N',
                 'GPSLongitude'    => array('0/0', '0/0', '0/0'),
+                'GPSLongitudeRef' => 'W',
+            ),
+            '71.706936,-42.604303' => array(
+                'GPSLatitude'     => array('71.706936'),
+                'GPSLatitudeRef'  => 'N',
+                'GPSLongitude'    => array('42.604303'),
                 'GPSLongitudeRef' => 'W',
             ),
         );


### PR DESCRIPTION
The native mapper will throw up an error – "Division by zero" – if one or both of the coordinates (Latitude/Longitude) are set to 0 (which is valid).

Also added checks for "GPSLatitudeRef" and "GPSLongitudeRef" tags.