### PR TITLE
Fixed normalization of exposure time

### DIFF
--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -346,8 +346,8 @@ class Exif
             return false;
         }
 
-        if (is_float($this->data[self::EXPOSURE])) {
-            return $this->data[self::EXPOSURE];
+        if (is_numeric($this->data[self::EXPOSURE])) {
+            return $this->data[self::EXPOSURE] + 0;
         }
 
         $exposureParts = explode('/', $this->data[self::EXPOSURE]);

--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -346,6 +346,10 @@ class Exif
             return false;
         }
 
+        if (is_float($this->data[self::EXPOSURE])) {
+            return $this->data[self::EXPOSURE];
+        }
+
         $exposureParts = explode('/', $this->data[self::EXPOSURE]);
 
         return (int) reset($exposureParts) / (int) end($exposureParts);

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -143,7 +143,14 @@ class Exiftool implements MapperInterface
                     }
                     break;
                 case self::EXPOSURETIME:
-                    $value = '1/' . round(1 / $value);
+                    // Based on the source code of Exiftool (PrintExposureTime subroutine):
+                    // http://cpansearch.perl.org/src/EXIFTOOL/Image-ExifTool-9.90/lib/Image/ExifTool/Exif.pm
+                    if ($value < 0.25001 && $value > 0) {
+                        $value = sprintf('1/%d', intval(0.5 + 1 / $value));
+                    } else {
+                        $value = sprintf('%.1f', $value);
+                        $value = preg_replace('/.0$/', '', $value);
+                    }
                     break;
                 case self::FOCALLENGTH:
                     $focalLengthParts = explode(' ', $value);

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -219,10 +219,19 @@ class ExifTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetExposureMilliseconds()
     {
-        $expected = 1/320;
-        $data[\PHPExif\Exif::EXPOSURE] = '1/320';
-        $this->exif->setData($data);
-        $this->assertEquals($expected, $this->exif->getExposureMilliseconds());
+        $rawData = array(
+            array(1/300, '1/300'),
+            array(0.0025, 0.0025),
+        );
+
+        foreach ($rawData as $data) {
+            $expected = reset($data);
+            $value = end($data);
+
+            $data[\PHPExif\Exif::EXPOSURE] = $value;
+            $this->exif->setData($data);
+            $this->assertEquals($expected, $this->exif->getExposureMilliseconds());
+        }
     }
 
     /**

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -138,12 +138,19 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::EXPOSURETIME => 1/400,
+            '1/30'  => 10/300,
+            '1/400' => 2/800,
+            '1/400' => 1/400,
+            '0'     => 0,
         );
 
-        $mapped = $this->mapper->mapRawData($rawData);
+        foreach ($rawData as $expected => $value) {
+            $mapped = $this->mapper->mapRawData(array(
+                \PHPExif\Mapper\Exiftool::EXPOSURETIME => $value,
+            ));
 
-        $this->assertEquals('1/400', reset($mapped));
+            $this->assertEquals($expected, reset($mapped));
+        }
     }
 
     /**

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -108,12 +108,19 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::EXPOSURETIME => '2/800',
+            '1/30'  => 10/300,
+            '1/400' => 2/800,
+            '1/400' => 1/400,
+            '0'     => 0,
         );
 
-        $mapped = $this->mapper->mapRawData($rawData);
+        foreach ($rawData as $expected => $value) {
+            $mapped = $this->mapper->mapRawData(array(
+                \PHPExif\Mapper\Native::EXPOSURETIME => $value,
+            ));
 
-        $this->assertEquals('1/400', reset($mapped));
+            $this->assertEquals($expected, reset($mapped));
+        }
     }
 
     /**
@@ -250,5 +257,28 @@ class NativeMapperTest extends \PHPUnit_Framework_TestCase
             reset($rawData),
             $result
         );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::normalizeComponent
+     */
+    public function testNormalizeComponentCorrectly()
+    {
+        $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\Native', 'normalizeComponent');
+        $reflMethod->setAccessible(true);
+
+        $rawData = array(
+            '2/800' => 0.0025,
+            '1/400' => 0.0025,
+            '0/1'   => 0,
+            '0'     => 0,
+        );
+
+        foreach ($rawData as $value => $expected) {
+            $normalized = $reflMethod->invoke($this->mapper, $value);
+
+            $this->assertEquals($expected, $normalized);
+        }
     }
 }


### PR DESCRIPTION
If the exposure time is set to 0, the exiftool mapper will throw up – "Division by zero".

Also there were some differences between those two mappers so I fixed it (based on source code of the Exiftool).