### PR TITLE
Allowed for duplicated tags in the raw data

### DIFF
--- a/lib/PHPExif/Adapter/Exiftool.php
+++ b/lib/PHPExif/Adapter/Exiftool.php
@@ -102,7 +102,7 @@ class Exiftool extends AdapterAbstract
     {
         $result = $this->getCliOutput(
             sprintf(
-                '%1$s%3$s -j -c %4$s %2$s',
+                '%1$s%3$s -j -a -G0 -c %4$s %2$s',
                 $this->getToolPath(),
                 escapeshellarg($file),
                 $this->numeric ? ' -n' : '',

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -24,34 +24,34 @@ use DateTime;
  */
 class Exiftool implements MapperInterface
 {
-    const APERTURE                 = 'Aperture';
-    const APPROXIMATEFOCUSDISTANCE = 'ApproximateFocusDistance';
-    const ARTIST                   = 'Artist';
-    const CAPTION                  = 'Caption';
-    const CAPTIONABSTRACT          = 'Caption-Abstract';
-    const COLORSPACE               = 'ColorSpace';
-    const COPYRIGHT                = 'Copyright';
-    const CREATEDATE               = 'CreateDate';
-    const CREDIT                   = 'Credit';
-    const EXPOSURETIME             = 'ExposureTime';
-    const FILESIZE                 = 'FileSize';
-    const FOCALLENGTH              = 'FocalLength';
-    const HEADLINE                 = 'Headline';
-    const IMAGEHEIGHT              = 'ImageHeight';
-    const IMAGEWIDTH               = 'ImageWidth';
-    const ISO                      = 'ISO';
-    const JOBTITLE                 = 'JobTitle';
-    const KEYWORDS                 = 'Keywords';
-    const MIMETYPE                 = 'MIMEType';
-    const MODEL                    = 'Model';
-    const ORIENTATION              = 'Orientation';
-    const SOFTWARE                 = 'Software';
-    const SOURCE                   = 'Source';
-    const TITLE                    = 'Title';
-    const XRESOLUTION              = 'XResolution';
-    const YRESOLUTION              = 'YResolution';
-    const GPSLATITUDE              = 'GPSLatitude';
-    const GPSLONGITUDE             = 'GPSLongitude';
+    const APERTURE                 = 'Composite:Aperture';
+    const APPROXIMATEFOCUSDISTANCE = 'XMP:ApproximateFocusDistance';
+    const ARTIST                   = 'EXIF:Artist';
+    const CAPTION                  = 'XMP:Caption';
+    const CAPTIONABSTRACT          = 'IPTC:Caption-Abstract';
+    const COLORSPACE               = 'EXIF:ColorSpace';
+    const COPYRIGHT                = 'EXIF:Copyright';
+    const CREATEDATE               = 'EXIF:CreateDate';
+    const CREDIT                   = 'IPTC:Credit';
+    const EXPOSURETIME             = 'EXIF:ExposureTime';
+    const FILESIZE                 = 'File:FileSize';
+    const FOCALLENGTH              = 'EXIF:FocalLength';
+    const HEADLINE                 = 'IPTC:Headline';
+    const IMAGEHEIGHT              = 'File:ImageHeight';
+    const IMAGEWIDTH               = 'File:ImageWidth';
+    const ISO                      = 'EXIF:ISO';
+    const JOBTITLE                 = 'IPTC:By-lineTitle';
+    const KEYWORDS                 = 'IPTC:Keywords';
+    const MIMETYPE                 = 'File:MIMEType';
+    const MODEL                    = 'EXIF:Model';
+    const ORIENTATION              = 'EXIF:Orientation';
+    const SOFTWARE                 = 'EXIF:Software';
+    const SOURCE                   = 'IPTC:Source';
+    const TITLE                    = 'IPTC:ObjectName';
+    const XRESOLUTION              = 'EXIF:XResolution';
+    const YRESOLUTION              = 'EXIF:YResolution';
+    const GPSLATITUDE              = 'EXIF:GPSLatitude';
+    const GPSLONGITUDE             = 'EXIF:GPSLongitude';
 
     /**
      * Maps the ExifTool fields to the fields of
@@ -153,8 +153,10 @@ class Exiftool implements MapperInterface
                     }
                     break;
                 case self::FOCALLENGTH:
-                    $focalLengthParts = explode(' ', $value);
-                    $value = (int) reset($focalLengthParts);
+                    if (!$this->numeric || strpos($value, ' ') !== false) {
+                        $focalLengthParts = explode(' ', $value);
+                        $value = reset($focalLengthParts);
+                    }
                     break;
                 case self::GPSLATITUDE:
                     $gpsData['lat']  = $this->extractGPSCoordinates($value);
@@ -170,8 +172,8 @@ class Exiftool implements MapperInterface
 
         // add GPS coordinates, if available
         if (count($gpsData) === 2 && $gpsData['lat'] !== false && $gpsData['lon'] !== false) {
-            $latitudeRef = empty($data['GPSLatitudeRef'][0]) ? 'N' : $data['GPSLatitudeRef'][0];
-            $longitudeRef = empty($data['GPSLongitudeRef'][0]) ? 'E' : $data['GPSLongitudeRef'][0];
+            $latitudeRef = empty($data['EXIF:GPSLatitudeRef'][0]) ? 'N' : $data['EXIF:GPSLatitudeRef'][0];
+            $longitudeRef = empty($data['EXIF:GPSLongitudeRef'][0]) ? 'E' : $data['EXIF:GPSLongitudeRef'][0];
 
             $gpsLocation = sprintf(
                 '%s,%s',

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -177,10 +177,10 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->setNumeric(false);
         $result = $this->mapper->mapRawData(
             array(
-                'GPSLatitude'     => '40 deg 20\' 0.42857" N',
-                'GPSLatitudeRef'  => 'North',
-                'GPSLongitude'    => '20 deg 10\' 2.33333" W',
-                'GPSLongitudeRef' => 'West',
+                'EXIF:GPSLatitude'     => '40 deg 20\' 0.42857" N',
+                'EXIF:GPSLatitudeRef'  => 'North',
+                'EXIF:GPSLongitude'    => '20 deg 10\' 2.33333" W',
+                'EXIF:GPSLongitudeRef' => 'West',
             )
         );
 
@@ -197,10 +197,10 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->mapper->mapRawData(
             array(
-                'GPSLatitude'     => '40.333452381',
-                'GPSLatitudeRef'  => 'North',
-                'GPSLongitude'    => '20.167314814',
-                'GPSLongitudeRef' => 'West',
+                'EXIF:GPSLatitude'     => '40.333452381',
+                'EXIF:GPSLatitudeRef'  => 'North',
+                'EXIF:GPSLongitude'    => '20.167314814',
+                'EXIF:GPSLongitudeRef' => 'West',
             )
         );
 
@@ -218,10 +218,10 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->setNumeric(false);
         $result = $this->mapper->mapRawData(
             array(
-                'GPSLatitude'     => '40.333452381',
-                'GPSLatitudeRef'  => 'North',
-                'GPSLongitude'    => '20.167314814',
-                'GPSLongitudeRef' => 'West',
+                'EXIF:GPSLatitude'     => '40.333452381',
+                'EXIF:GPSLatitudeRef'  => 'North',
+                'EXIF:GPSLongitude'    => '20.167314814',
+                'EXIF:GPSLongitudeRef' => 'West',
             )
         );
 
@@ -236,8 +236,8 @@ class ExiftoolMapperTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->mapper->mapRawData(
             array(
-                'GPSLatitude'     => '40.333452381',
-                'GPSLatitudeRef'  => 'North',
+                'EXIF:GPSLatitude'    => '40.333452381',
+                'EXIF:GPSLatitudeRef' => 'North',
             )
         );
 


### PR DESCRIPTION
When duplicated tags exist (like `EXIF:CreateDate` and `XMP:CreateDate`), only one is extracted (as `CreatedDate`). Because of that it's really hard to check all the values (for example, to compare). See [ExifTool FAQ](http://www.sno.phy.queensu.ca/~phil/exiftool/faq.html#Q3).

I've changed the arguments of a command to show duplicated tags in the raw data array, prefixed with `Group:` (`ExifTool` mapper only).