### PR TITLE
Support for Unicode Exiftool output added

### DIFF
--- a/lib/PHPExif/Adapter/Exiftool.php
+++ b/lib/PHPExif/Adapter/Exiftool.php
@@ -110,7 +110,7 @@ class Exiftool extends AdapterAbstract
             )
         );
 
-        $data = json_decode($result, true);
+        $data = json_decode(utf8_encode($result), true);
 
         // map the data:
         $mapper = $this->getMapper();


### PR DESCRIPTION
Noticed that the exiftool json output could contain unicode characters in some rare cases. Fixed it.

See attached file for testing. 

![europress-getty1](https://cloud.githubusercontent.com/assets/3766124/13085538/07316242-d4df-11e5-928c-dfc442a0884d.jpg)