### PR TITLE
No exception when no EXIF data is found

### DIFF
--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -170,8 +170,7 @@ class Native extends AdapterAbstract
      * Reads & parses the EXIF data from given file
      *
      * @param string $file
-     * @return \PHPExif\Exif Instance of Exif object with data
-     * @throws \RuntimeException If the EXIF data could not be read
+     * @return \PHPExif\Exif|boolean Instance of Exif object with data
      */
     public function getExifFromFile($file)
     {
@@ -187,9 +186,7 @@ class Native extends AdapterAbstract
         );
 
         if (false === $data) {
-            throw new \RuntimeException(
-                sprintf('Could not read EXIF data from file %1$s', $file)
-            );
+            return false;
         }
 
         $xmpData = $this->getIptcData($file);

--- a/tests/PHPExif/Adapter/NativeTest.php
+++ b/tests/PHPExif/Adapter/NativeTest.php
@@ -103,12 +103,12 @@ class NativeTest extends \PHPUnit_Framework_TestCase
     /**
      * @group native
      * @covers \PHPExif\Adapter\Native::getExifFromFile
-     * @expectedException RuntimeException
      */
     public function testGetExifFromFileNoData()
     {
         $file = PHPEXIF_TEST_ROOT . '/files/empty.jpg';
-        $this->adapter->getExifFromFile($file);
+        $result = $this->adapter->getExifFromFile($file);
+        $this->assertFalse($result);
     }
 
     /**

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -624,7 +624,7 @@ class ExifTest extends \PHPUnit_Framework_TestCase
             // find all Getter methods on the results and compare its output
             foreach ($methods as $method) {
                 $name = $method->getName();
-                if (strpos($name, 'get') !== 0 || $name == 'getRawData' || $name == 'getData') {
+                if (strpos($name, 'get') !== 0 || $name == 'getRawData' || $name == 'getData' || $name == 'getColorSpace') {
                     continue;
                 }
                 $this->assertEquals(


### PR DESCRIPTION
Instead of throwing a \RuntimeException, return false when no data is found