### PR TITLE
Use floatval() instead of intval() to avoid improper coord values

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -204,7 +204,7 @@ class Exiftool implements MapperInterface
                 return false;
             }
 
-            return intval($matches[1]) + (intval($matches[2]) / 60) + (floatval($matches[3]) / 3600);
+            return floatval($matches[1]) + (floatval($matches[2]) / 60) + (floatval($matches[3]) / 3600);
         }
     }
 }

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -260,7 +260,7 @@ class Native implements MapperInterface
         $components = array_map(array($this, 'normalizeComponent'), $components);
 
         if (count($components) > 2) {
-            return intval($components[0]) + (intval($components[1]) / 60) + (floatval($components[2]) / 3600);
+            return floatval($components[0]) + (floatval($components[1]) / 60) + (floatval($components[2]) / 3600);
         }
 
         return reset($components);


### PR DESCRIPTION
On my php 7.2 machine exif coord values for latitude and longitude were rounded to improper values.

Correct: `52.268676666667,10.510951666667`
Wrong: `52.266666666667,10,5`

I changed `intval()` to `floatval()` in both mappers and all values are computed as excepted.